### PR TITLE
Version 1.2.4

### DIFF
--- a/backend/db/model/dataUpload.js
+++ b/backend/db/model/dataUpload.js
@@ -15,7 +15,7 @@ var dataUploadSchema = new Schema({
         sig: {type: String, required: false},
         start_date: {type: Date, required: false},
         end_date: {type: Date, required: false},
-        num_records: {type: Number, required: true},
+        num_records: {type: Number, required: false},
         title: {type: String, required: false},
         description: {type: String, required: false},
         type: {type: String, required: false},

--- a/backend/db/model/dataUpload.js
+++ b/backend/db/model/dataUpload.js
@@ -15,6 +15,7 @@ var dataUploadSchema = new Schema({
         sig: {type: String, required: false},
         start_date: {type: Date, required: false},
         end_date: {type: Date, required: false},
+        num_records: {type: Number, required: true},
         title: {type: String, required: false},
         description: {type: String, required: false},
         type: {type: String, required: false},

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Brandon Sharratt",
   "description": "Metadata Curator is a simple web app to edit csvs and to help describe, validate and share usable open data",
   "repository": "https://github.com/bcgov/metadata-curator",

--- a/backend/routes/base/uploads.js
+++ b/backend/routes/base/uploads.js
@@ -351,7 +351,7 @@ var buildDynamic = function(db, router, auth, forumClient, notify, revisionServi
     router.delete('/:dataUploadId', auth.requireAdmin, async function(req, res, next){
         
         try{
-            await db.DataUploadSchema.deleteOne({id: req.params.dataUploadId});
+            await db.DataUploadSchema.deleteOne({_id: req.params.dataUploadId});
             return res.status(204).json({});
         }catch(ex){
             res.status(500).json({ex});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/frontend/src/changelog.md
+++ b/frontend/src/changelog.md
@@ -2,6 +2,37 @@
 
 <br />
 
+## Version 1.2.4
+February 7, 2022
+ - Fixed issue where delting a data upload would delete the oldest instead of the selected one
+ - Changed selection of upload on edition to allow a searchable table
+ - Added ability to collapse resources on schema view to improve navigation
+ - Added close/back to schema compare page
+ - Hyperlinked Data Upload on Edition page to the data upload it relates to (non edit only)
+ - Made it so that field comments properly expand the field box when there is multiple
+ - Fixed issue where select wasn't showing the proper display value
+ - Removed approved versions from list on upload
+ - Removed ability to create new datasets/editions on the upload page
+ - Fixed issue where variable classifications would prevent basic view of schema
+ - Added next button to top of compare schema on upload
+ - Edition select on upload now saves information into the selected version to bind to the upload
+    - This will warn if the edition has that information already but not prevent it from being overwritten
+ - Added back/close, edit to top of schema page
+ - Added dataset tab to schema page
+    - This closes the dialog if your in a dialog, or shows you the dataset information if you aren't
+ - Added Number of records to file info page for data type files
+
+
+
+<br />
+
+## Table Of Contents
+- [Version 1.2.4 (February 8 2022)](#version-124)
+- [Version 1.2.3 (February 1 2022)](#version-123)
+- [Version 1.2.2 (January 27 2022)](#version-122)
+
+<br />
+
 ## Version 1.2.3
 February 1, 2022
  - Changed value and display for variable classification on schema to be "code. name"
@@ -14,13 +45,7 @@ February 1, 2022
  - Added first of filters to the basic schema view, allows filtering on variable classification.
  - Fixed issue updating variable classifications as non admin
 
-<br />
-
-## Table Of Contents
-- [Version 1.2.3 (February 1 2022)](#version-123)
-- [Version 1.2.2 (January 27 2022)](#version-122)
-
-<br />
+ <br />
 
 ## Version 1.2.2 
 January 27, 2022

--- a/frontend/src/components/BranchForm.vue
+++ b/frontend/src/components/BranchForm.vue
@@ -13,6 +13,7 @@
             <v-col cols="12">
                 <v-tabs v-model="tab">
                     <v-tab key="version">{{$tc('Version')}}</v-tab>
+                    <v-tab v-if="dataset" key="dataset" @click="dialog ? closeOrBack() : true">{{$tc('Dataset')}}</v-tab>
                     <v-tab key="schema" v-if="!creating">{{$tc('Schema')}}</v-tab>
                     <v-tab key="compare" v-if="!creating && inferredSchema">{{$tc('Compare')}}</v-tab>
                 </v-tabs>
@@ -249,12 +250,20 @@
                         </v-card>
                     </v-tab-item>
 
+                    <v-tab-item key="dataset">
+                        <span v-if="branch && branch.repo_id && branch.repo_id._id">
+                            <DatasetForm :hideEditions="true" :idOverride="branch.repo_id._id"></DatasetForm>
+                            <v-btn @click="closeOrBack()" class="mt-1">{{dialog ? $tc('Close') : $tc('Back')}}</v-btn>
+                        </span>
+                    </v-tab-item>
+
                     <v-tab-item key="schema" v-if="!creating">
                         <MetadataForm @setComment="(e) => { setComment(e) }" :branch-approved="(branch && branch.approved) ? branch.approved : false" @commentRefs="(e) => updateCommentRefs(e)" :branchId="id" @close="closeOrBack" :dialog="dialog"></MetadataForm>
                     </v-tab-item>
 
                     <v-tab-item key="compare" v-if="!creating && inferredSchema">
                         <Comparison :left-side-text="JSON.stringify(inferredSchema)" :right-side-text="JSON.stringify(schema)" :diff-json="true"></Comparison>
+                        <v-btn @click="closeOrBack()" class="mt-1">{{dialog ? $tc('Close') : $tc('Back')}}</v-btn>
                     </v-tab-item>
                 </v-tabs-items>
             </v-col>
@@ -278,6 +287,7 @@ import Markdown from './Markdown';
 import MetadataForm from './MetadataForm';
 import Comments from './Comments';
 import Comparison from './Comparison';
+import DatasetForm from './DatasetForm';
 
 import Vue from 'vue';
 import SimpleCheckbox from './SimpleCheckbox';
@@ -293,7 +303,8 @@ export default {
         Markdown,
         Comments,
         Comparison,
-        DataUploadSelect
+        DataUploadSelect,
+        DatasetForm,
     },
     props: {
         dialog: {
@@ -361,10 +372,8 @@ export default {
             if (this.branch.variable_classification){
                 await this.getVariableClassification({field: '_id', value: this.branch.variable_classification});
             }
-            
-            //await this.getRepos({filterBy: ''});
-            //await this.getDataset({id: this.branch.repo_id});
             this.reIndex++;
+            
         },
 
         async closeOrBack() {

--- a/frontend/src/components/Comments.vue
+++ b/frontend/src/components/Comments.vue
@@ -1,66 +1,80 @@
 <template>
-    <div>
-        <div v-if="commentDisplayItems.length == 0 && type !== 'schema'" class="ml-3">
-            {{$tc('Nothing here yet, why not start a discussion')}}
-        </div>
+    <v-container fluid>
+        <v-row v-if="commentDisplayItems.length == 0 && type !== 'schema'" class="ml-3">
+            <v-col cols=12>
+                {{$tc('Nothing here yet, why not start a discussion')}}
+            </v-col>
+        </v-row>
 
-        <div v-if="commentDisplayItems.length == 0 && type === 'schema'" class="ml-3">
-            {{$tc('No comments about this field, reference with ')}}!{{resource}}.{{field}}
-        </div>
-        <v-list v-else three-line class="mb-3">
-            <template v-for="(item, index) in commentDisplayItems">
-                    <v-divider
-                        v-if="item.divider"
-                        :key="index"
-                        :inset="item.inset"
-                    ></v-divider>
+        <v-row v-if="commentDisplayItems.length == 0 && type === 'schema'" class="ml-3">
+            <v-col cols=12>
+                {{$tc('No comments about this field, reference with ')}}!{{resource}}.{{field}}
+            </v-col>
+        </v-row>
+        <v-row v-else>
+            <v-col cols=12>
+                <v-list three-line class="mb-3">
+                    <template v-for="(item, index) in commentDisplayItems">
+                            <v-divider
+                                v-if="item.divider"
+                                :key="index"
+                                :inset="item.inset"
+                            ></v-divider>
 
-                    <v-list-item
-                        v-else
-                        :key="item.title"
-                    >
-                        <v-btn icon :key="'comment-icon-btn-'+index+'-'+refreshKey" class="mr-4">
-                            <v-icon>mdi-comment-multiple</v-icon>
-                        </v-btn>
+                            <v-list-item
+                                v-else
+                                :key="item.title"
+                            >
+                                <v-btn icon :key="'comment-icon-btn-'+index+'-'+refreshKey" class="mr-4">
+                                    <v-icon>mdi-comment-multiple</v-icon>
+                                </v-btn>
 
-                        <v-btn x-small @click="expand(index)">
-                            <v-icon>{{expanded[index] ? 'mdi-minus' : 'mdi-plus'}}</v-icon>
-                        </v-btn>
+                                <v-btn x-small @click="expand(index)">
+                                    <v-icon>{{expanded[index] ? 'mdi-minus' : 'mdi-plus'}}</v-icon>
+                                </v-btn>
 
-                        <v-list-item-content>
-                            <v-list-item-title :class="expanded[index] ? 'expanded' : ''">
-                                <Markdown
-                                    name=""
-                                    :value="item.content"
-                                    :label="$tc('')"
-                                    :editing="false"
-                                    :placeholder="$tc('')"
-                                ></Markdown>
-                            </v-list-item-title>
-                            <v-list-item-action-text v-html="item.subtitle"></v-list-item-action-text>
-                        </v-list-item-content>
+                                <v-list-item-content>
+                                    <v-list-item-title :class="expanded[index] ? 'expanded' : ''">
+                                        <Markdown
+                                            name=""
+                                            :value="item.content"
+                                            :label="$tc('')"
+                                            :editing="false"
+                                            :placeholder="$tc('')"
+                                        ></Markdown>
+                                    </v-list-item-title>
+                                    <v-list-item-action-text v-html="item.subtitle"></v-list-item-action-text>
+                                </v-list-item-content>
 
-                </v-list-item>
-            </template>
-        </v-list>
-        <div v-if="type !== 'schema'">
-            <Markdown
-                name="comment"
-                :value="comment"
-                :key="'md-comment-'+refreshKey"
-                :label="$tc('New Comment')"
-                :editing="true"
-                :placeholder="$tc('New Comment')"
-                @focus="commentFocused = true"
-                @blur="commentFocused = false"
-                @edited="(newValue) => { setComment(newValue) }"
-            ></Markdown>
-            <v-btn color="primary" @click="addComment" :disabled="comment === ''" v-if="(comment !== '') || commentFocused">Add Comment</v-btn>
-        </div>
-        <div v-else>
-            <v-btn color="primary" @click="scrollBottom">Add a comment below</v-btn>
-        </div>
-    </div>
+                        </v-list-item>
+                    </template>
+                </v-list>
+            </v-col>
+        </v-row>
+        <v-row v-if="type !== 'schema'">
+            <v-col cols=12>
+                <Markdown
+                    name="comment"
+                    :value="comment"
+                    :key="'md-comment-'+refreshKey"
+                    :label="$tc('New Comment')"
+                    :editing="true"
+                    :placeholder="$tc('New Comment')"
+                    @focus="commentFocused = true"
+                    @blur="commentFocused = false"
+                    @edited="(newValue) => { setComment(newValue) }"
+                ></Markdown>
+            </v-col>
+            <v-col cols=12>
+                <v-btn color="primary" @click="addComment" :disabled="comment === ''" v-if="(comment !== '') || commentFocused">Add Comment</v-btn>
+            </v-col>
+        </v-row>
+        <v-row v-else>
+            <v-col cols=12>
+                <v-btn color="primary" @click="scrollBottom">Add a comment below</v-btn>
+            </v-col>
+        </v-row>
+    </v-container>
 </template>
 
 <script>

--- a/frontend/src/components/DataUploadSelect.vue
+++ b/frontend/src/components/DataUploadSelect.vue
@@ -19,33 +19,47 @@
                     <span>&nbsp;{{$t('help.'+((helpPrefix) ? helpPrefix + '.' + name : name))}}</span>
                 </v-tooltip>
             </span>
-            <h2 v-if="large">{{displayVal}}</h2>
-            <span v-else>{{displayVal}}</span>
+            <h2 v-if="large"><router-link :to="{ name: 'upload_view', params: {id: this.val} }">{{displayVal}}</router-link></h2>
+            <span v-else><router-link :to="{ name: 'upload_view', params: {id: this.val} }">{{displayVal}}</router-link></span>
         </span>
 
         <span v-else>
             <ValidationProvider :rules="validationRules" v-slot="{ errors }" :name="label ? $tc(label) : $tc(name)">
-                <v-select
-                    :name="name"
-                    v-model="val"
-                    :items="items"
-                    :item-text="itemText"
-                    :item-value="itemValue"
-                    :id="idName ? idName : ''"
-                    :error-messages="errors.length > 0 ? [errors[0]] : []"
-                    @change="$emit('edited', val)"
-                    outlined
-                >
-                    <template v-slot:label>
-                        {{$tc(displayLabel)}}
-                        <v-tooltip right v-if="$te('help.'+((helpPrefix) ? helpPrefix + '.' + name : name))">
-                            <template v-slot:activator="{ on }">
-                                <v-icon color="label_colour" v-on="on">mdi-help-circle-outline</v-icon>
-                            </template>
-                            <span>&nbsp;{{$t('help.'+((helpPrefix) ? helpPrefix + '.' + name : name))}}</span>
-                        </v-tooltip>
+                <v-dialog persistent v-model="dialog">
+                    <template v-slot:activator="{ on }">
+                        <component :is="(large) ? 'h2' : 'span'">{{displayLabel}}</component>
+                        <v-btn v-on="on">{{displayVal}}<v-icon>mdi-dock-window</v-icon></v-btn>
                     </template>
-                </v-select>
+                    <v-card>
+                        <v-card-title>
+                            <span class="headline">Select an {{ $tc('Uploads', 1) }}</span>
+                            <v-spacer></v-spacer>
+                            <v-btn small @click="dialog = false">X</v-btn>
+                        </v-card-title>
+
+                        <v-card-text>
+                            <v-data-table
+                                dense
+                                class="dataUploadSelectTable"
+                                :search="searchString"
+                                :headers="headers"
+                                :items="items"
+                                @click:row="rowClicked"
+                            >
+                                <template v-slot:top>
+                                    <v-text-field
+                                        v-model="searchString"
+                                        label="Search"
+                                    ></v-text-field>
+                                </template>
+                            </v-data-table>
+                        </v-card-text>
+
+                        <v-card-actions>
+                        </v-card-actions>
+                    </v-card>
+                </v-dialog>
+                
             </ValidationProvider>
         </span>
     </div>
@@ -120,7 +134,28 @@
         },
         data() {
             return {
-                val: null
+                val: null,
+                dialog: false,
+                searchString: '',
+                headers: [
+                    {
+                        text: this.$tc('Name'),
+                        sortable: true,
+                        value: 'name'
+                    },
+                    { 
+                        text: this.$tc('Created'), 
+                        value: 'create_date' 
+                    },
+                    { 
+                        text: this.$tc('Description'), 
+                        value: 'description' 
+                    },
+                    { 
+                        text: this.$tc('Status'), 
+                        value: 'status' 
+                    },
+                ]
             }
         },
         computed: {
@@ -134,7 +169,7 @@
             displayVal: function(){
                 let displayVal = this.val;
                 for (let i=0; i<this.items.length; i++){
-                    if (this.items[i].value === this.val){
+                    if (this.items[i][this.itemValue] === this.val){
                         displayVal = this.items[i][this.itemText];
                     }
                 }
@@ -149,11 +184,23 @@
         },
         mounted(){
             this.val = this.value;
+        },
+        methods: {
+            rowClicked: function(item){
+                this.$emit('edited', item[this.itemValue]);
+                this.val = item[this.itemValue];
+                this.dialog = false;
+            }
         }
+
 
     };
 </script>
 
-<style scoped>
+<style>
+
+.dataUploadSelectTable tr:hover{
+    cursor: pointer;
+}
 
 </style>

--- a/frontend/src/components/DatasetForm.vue
+++ b/frontend/src/components/DatasetForm.vue
@@ -156,7 +156,7 @@
                             </v-col>
                         </v-row>
 
-                        <v-row wrap v-if="!creating">
+                        <v-row wrap v-if="!creating && !hideEditions">
                             <v-col cols=3>
                                 <h2>{{$tc('Versions', 2)}}</h2>
                             </v-col>
@@ -176,11 +176,11 @@
 
                     </v-card-text>
                 </v-card>
-                <v-card-actions v-if="editing">
+                <v-card-actions v-if="editing && !hideEditions">
                     <v-btn @click="routeToHome()" class="mt-1">{{$tc('Cancel')}}</v-btn>
                     <v-btn @click="save" class="mt-1" color="primary">{{$tc('Save')}}</v-btn>
                 </v-card-actions>
-                <v-card-actions v-else>
+                <v-card-actions v-else-if="!editing && !hideEditions">
                     <v-btn @click="routeToHome()" class="mt-1">{{$tc('Back')}}</v-btn>
                     <v-btn @click="editing=!editing" class="mt-1" color="primary">{{$tc('Edit')}}</v-btn>
                 </v-card-actions>
@@ -204,7 +204,19 @@ export default {
         BranchForm,
         SimpleCheckbox,
         Select
-    },    
+    },
+
+    props: {
+        idOverride: {
+            required: false,
+            default: false,
+        },
+        hideEditions: {
+            required: false,
+            default: false,
+        },
+    },
+
     data () {
         return {
             id: null,
@@ -355,7 +367,11 @@ export default {
     },
     created() {
         // console.log("dataUpload id: " + this.$route.params.id);
+        
         this.id = this.$route.params.id;
+        if (this.idOverride){
+            this.id = this.idOverride;
+        }
         if (this.id === 'create'){
             this.editing = true;
             this.creating = true;

--- a/frontend/src/components/FileInfoForm.vue
+++ b/frontend/src/components/FileInfoForm.vue
@@ -89,6 +89,22 @@
                             ></TextArea>
                         </v-col>
                     </v-row>
+
+                    <v-row v-if="type[index] === 'Data'">
+                        <TextInput
+                            :label="$tc('Number of Records')"
+                            :placeholder="$tc('2022')"
+                            name="num_records"
+                            :editing="true"
+                            :value="(num_records[index]) ? num_records[index] : ''"
+                            helpPrefix="upload"
+                            :idName="'fileinfo-'+ index + '-num_records'"
+                            @edited="(newValue) => { ( num_records[index] = newValue) && updateFormSubmission }"
+                        ></TextInput>
+                    </v-row>
+                    <v-row v-else>
+                        {{$tc('Record number not required for non data type files')}}
+                    </v-row>
                 </v-col>
             </v-row>   
         </span>    

--- a/frontend/src/components/JsonEditor/JsonEditor.vue
+++ b/frontend/src/components/JsonEditor/JsonEditor.vue
@@ -38,6 +38,11 @@
                     </v-col>
                     <v-col v-for="(resource, key) in workingVal.resources" :key="'basic-resource-'+key+'-'+reindexKey" cols=12 :class="editing ? 'field' : ''">
                         <v-row v-if="(resource && resource.name) || editing" class="pb-2">
+                            <v-col cols=3>
+                                <v-btn x-small @click="toggleExpandedBasicResource(key)"><v-icon>{{expandedBasicResource[key] ? 'mdi-minus' : 'mdi-plus'}}</v-icon></v-btn>
+                            </v-col>
+                            <v-col cols=9>
+                            </v-col>
                             <v-col cols=12>
                                 <TextInput
                                     :label="$tc('Resource', 1) + ' ' + $tc('Name')"
@@ -56,342 +61,346 @@
                             </v-col>
                            
                         </v-row>
-                        <v-row v-if="(resource && resource.path) || editing" class="pb-2">
-                            <v-col cols=12>
-                                <TextInput
-                                    :label="$tc('Path')"
-                                    placeholder=""
-                                    name="path"
-                                    :refName="'basicField-' + key + '-path'"
-                                    :idName="'basicField-' + key + '-path'"
-                                    :large="true"
-                                    :editing="editing"
-                                    :value="resource.path"
-                                    helpPrefix="schema"
-                                    :focusField="focusProp"
-                                    @focus="onFocusBasic"
-                                    @blur="(event) => { updateResourcePath(key, event) }"
-                                ></TextInput>
-                            </v-col>
-                           
-                        </v-row>
-                        <v-row v-if="(resource && resource.description) || editing" class="pb-2">
-                            <v-col cols=12>
-                                <TextInput
-                                    :label="$tc('Description (resource)')"
-                                    placeholder=""
-                                    name="description"
-                                    :refName="'basicField-' + key + '-description'"
-                                    :idName="'basicField-' + key + '-description'"
-                                    :large="true"
-                                    :editing="editing"
-                                    :value="resource.description"
-                                    helpPrefix="schema"
-                                    :focusField="focusProp"
-                                    @focus="onFocusBasic"
-                                    @blur="(event) => { updateResourceBase(key, 'description', event) }"
-                                ></TextInput>
-                            </v-col>
-                        </v-row>
+                        <span v-if="expandedBasicResource[key]">
+                            <v-row v-if="(resource && resource.path) || editing" class="pb-2">
+                                <v-col cols=12>
+                                    <TextInput
+                                        :label="$tc('Path')"
+                                        placeholder=""
+                                        name="path"
+                                        :refName="'basicField-' + key + '-path'"
+                                        :idName="'basicField-' + key + '-path'"
+                                        :large="true"
+                                        :editing="editing"
+                                        :value="resource.path"
+                                        helpPrefix="schema"
+                                        :focusField="focusProp"
+                                        @focus="onFocusBasic"
+                                        @blur="(event) => { updateResourcePath(key, event) }"
+                                    ></TextInput>
+                                </v-col>
+                            
+                            </v-row>
+                            <v-row v-if="(resource && resource.description) || editing" class="pb-2">
+                                <v-col cols=12>
+                                    <TextInput
+                                        :label="$tc('Description (resource)')"
+                                        placeholder=""
+                                        name="description"
+                                        :refName="'basicField-' + key + '-description'"
+                                        :idName="'basicField-' + key + '-description'"
+                                        :large="true"
+                                        :editing="editing"
+                                        :value="resource.description"
+                                        helpPrefix="schema"
+                                        :focusField="focusProp"
+                                        @focus="onFocusBasic"
+                                        @blur="(event) => { updateResourceBase(key, 'description', event) }"
+                                    ></TextInput>
+                                </v-col>
+                            </v-row>
 
-                         <v-row v-if="(resource && resource.temporal_start) || editing" class="pb-2">
-                            <v-col cols=12>
-                                <DateInput
-                                    :label="$tc('Date Range Start')"
-                                    :placeholder="(new Date()).toISOString().split('T')[0]"
-                                    name="temporal_start"
-                                    :editing="editing"
-                                    helpPrefix="schema"
-                                    :value="resource.temporal_start"
-                                    :large="true"
-                                    :refName="'basicField-' + key + '-temporal_start'"
-                                    :idName="'basicField-' + key + '-temporal_start'"
-                                    :focusField="focusProp"
-                                    @focus="onFocusBasic"
-                                    @edited="(newValue) => { updateResourceBase(key, 'temporal_start', newValue) }">
-                                </DateInput>
-                            </v-col>
-                        </v-row>
+                            <v-row v-if="(resource && resource.temporal_start) || editing" class="pb-2">
+                                <v-col cols=12>
+                                    <DateInput
+                                        :label="$tc('Date Range Start')"
+                                        :placeholder="(new Date()).toISOString().split('T')[0]"
+                                        name="temporal_start"
+                                        :editing="editing"
+                                        helpPrefix="schema"
+                                        :value="resource.temporal_start"
+                                        :large="true"
+                                        :refName="'basicField-' + key + '-temporal_start'"
+                                        :idName="'basicField-' + key + '-temporal_start'"
+                                        :focusField="focusProp"
+                                        @focus="onFocusBasic"
+                                        @edited="(newValue) => { updateResourceBase(key, 'temporal_start', newValue) }">
+                                    </DateInput>
+                                </v-col>
+                            </v-row>
 
-                        <v-row v-if="(resource && resource.temporal_end) || editing" class="pb-2">
-                            <v-col cols=12>
-                                <DateInput
-                                    :label="$tc('Date Range End')"
-                                    :placeholder="(new Date()).toISOString().split('T')[0]"
-                                    name="temporal_end"
-                                    :editing="editing"
-                                    helpPrefix="schema"
-                                    :value="resource.temporal_end"
-                                    :large="true"
-                                    :refName="'basicField-' + key + '-temporal_end'"
-                                    :idName="'basicField-' + key + '-temporal_end'"
-                                    :focusField="focusProp"
-                                    @focus="onFocusBasic"
-                                    @edited="(newValue) => { updateResourceBase(key, 'temporal_end', newValue) }">
-                                </DateInput>
-                            </v-col>
-                        </v-row>
+                            <v-row v-if="(resource && resource.temporal_end) || editing" class="pb-2">
+                                <v-col cols=12>
+                                    <DateInput
+                                        :label="$tc('Date Range End')"
+                                        :placeholder="(new Date()).toISOString().split('T')[0]"
+                                        name="temporal_end"
+                                        :editing="editing"
+                                        helpPrefix="schema"
+                                        :value="resource.temporal_end"
+                                        :large="true"
+                                        :refName="'basicField-' + key + '-temporal_end'"
+                                        :idName="'basicField-' + key + '-temporal_end'"
+                                        :focusField="focusProp"
+                                        @focus="onFocusBasic"
+                                        @edited="(newValue) => { updateResourceBase(key, 'temporal_end', newValue) }">
+                                    </DateInput>
+                                </v-col>
+                            </v-row>
 
-                        <v-row v-if="(resource && resource.source_system) || editing" class="pb-2">
-                            <v-col cols=12>
-                                <TextInput
-                                    :label="$tc('Source System')"
-                                    placeholder=""
-                                    name="source_system"
-                                    :refName="'basicField-' + key + '-source_system'"
-                                    :idName="'basicField-' + key + '-source_system'"
-                                    :large="true"
-                                    :editing="editing"
-                                    :value="resource.source_system"
-                                    helpPrefix="schema"
-                                    :focusField="focusProp"
-                                    @focus="onFocusBasic"
-                                    @blur="(event) => { updateResourceBase(key, 'source_system', event) }"
-                                ></TextInput>
-                            </v-col>
-                        </v-row>
+                            <v-row v-if="(resource && resource.source_system) || editing" class="pb-2">
+                                <v-col cols=12>
+                                    <TextInput
+                                        :label="$tc('Source System')"
+                                        placeholder=""
+                                        name="source_system"
+                                        :refName="'basicField-' + key + '-source_system'"
+                                        :idName="'basicField-' + key + '-source_system'"
+                                        :large="true"
+                                        :editing="editing"
+                                        :value="resource.source_system"
+                                        helpPrefix="schema"
+                                        :focusField="focusProp"
+                                        @focus="onFocusBasic"
+                                        @blur="(event) => { updateResourceBase(key, 'source_system', event) }"
+                                    ></TextInput>
+                                </v-col>
+                            </v-row>
 
 
-                        <span v-if="resource.schema && resource.schema.fields" style="width: 100%">
-                            <draggable v-bind:disabled="!editing" @end="dragEnd(key, $event)">
-                                <v-row 
-                                    :id="'fieldHeader-'+resource.name+'.'+field.name" 
-                                    v-for="(field, fKey) in resource.schema.fields" 
-                                    :key="'field-'+key+'-'+fKey+'-'+reindexKey" 
-                                    :class="'pa-0 relativePos' + ( (field && field.highlight && !editing) ? ' fieldHighlight': '') + (!filtered(field) ? ' field' : '')">
-                                    <div v-if="!filtered(field)"> 
-                                        <v-col cols=7>
-                                            <v-row no-gutters>
-                                                <v-col cols=3>
-                                                    <v-btn x-small @click="toggleExpandedBasic(key, fKey)"><v-icon>{{expandedBasic[key][fKey] ? 'mdi-minus' : 'mdi-plus'}}</v-icon></v-btn>
+                            <span v-if="resource.schema && resource.schema.fields" style="width: 100%">
+                                <draggable v-bind:disabled="!editing" @end="dragEnd(key, $event)">
+                                    <v-row 
+                                        :id="'fieldHeader-'+resource.name+'.'+field.name" 
+                                        no-gutters
+                                        v-for="(field, fKey) in resource.schema.fields" 
+                                        :key="'field-'+key+'-'+fKey+'-'+reindexKey" 
+                                        :class="'pa-0 relativePos' + ( (field && field.highlight && !editing) ? ' fieldHighlight': '') + (!filtered(field) ? ' field' : '')">
+                                        <v-container fluid v-if="!filtered(field)"> 
+                                            <v-row>
+                                                <v-col cols=7>
+                                                    <v-row no-gutters>
+                                                        <v-col cols=3>
+                                                            <v-btn x-small @click="toggleExpandedBasic(key, fKey)"><v-icon>{{expandedBasic[key][fKey] ? 'mdi-minus' : 'mdi-plus'}}</v-icon></v-btn>
+                                                        </v-col>
+                                                        <v-col cols=9></v-col>
+                                                        <v-col cols=12 v-if="(field && field.name) || editing" class="py-1">
+                                                            <TextInput
+                                                                :label="$tc('Name')"
+                                                                placeholder=""
+                                                                name="name"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-name'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-name'"
+                                                                
+                                                                :editing="editing"
+                                                                :value="field.name"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @blur="(event) => { updateResource(key, fKey, 'name', event) }"
+                                                                
+                                                                @focus="onFocusBasic"
+                                                                
+                                                            ></TextInput>
+                                                        </v-col>
+                                                        <v-col cols=12 v-if="((field && field.title) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Title')"
+                                                                placeholder=""
+                                                                name="title"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-title'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-title'"
+
+                                                                :editing="editing"
+                                                                :value="field.title"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'title', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.shortName) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Short Name')"
+                                                                placeholder=""
+                                                                name="shortName"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-shortName'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-shortName'"
+
+                                                                :editing="editing"
+                                                                :value="field.shortName"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'shortName', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.type) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Type')"
+                                                                placeholder=""
+                                                                name="type"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-type'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-type'"
+
+                                                                :editing="editing"
+                                                                :value="field.type"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'type', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.description) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Description')"
+                                                                placeholder=""
+                                                                name="description"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-description'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-description'"
+
+                                                                :editing="editing"
+                                                                :value="field.description"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'description', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.format) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Format')"
+                                                                placeholder=""
+                                                                name="format"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-format'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-format'"
+
+                                                                :editing="editing"
+                                                                :value="field.format"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'format', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.var_class) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <Select
+                                                                :label="$tc('Var Class')"
+                                                                placeholder=""
+                                                                name="var_class"
+                                                                :items="variableClassificationValues"
+                                                                itemText="code"
+                                                                itemValue="code"
+
+                                                                :editing="editing"
+                                                                :value="field.var_class"
+                                                                helpPrefix="schema"
+                                                                @edited="(newValue) => { updateResource(key, fKey, 'var_class', newValue) }"
+                                                            ></Select>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.rdfType) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('RDF Type')"
+                                                                placeholder=""
+                                                                name="rdfType"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-rdfType'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-rdfType'"
+
+                                                                :editing="editing"
+                                                                :value="field.rdfType"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'rdfType', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.tags) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Tags', 2)"
+                                                                placeholder=""
+                                                                name="tags"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-tags'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-tags'"
+
+                                                                :editing="editing"
+                                                                :value="field.tags"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'tags', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.comments) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Comments', 2)"
+                                                                placeholder=""
+                                                                name="comments"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-comments'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-comments'"
+
+                                                                :editing="editing"
+                                                                :value="field.comments"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResource(key, fKey, 'comments', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="((field && field.constraints && field.constraints.enum) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <TextInput
+                                                                :label="$tc('Enum', 1)"
+                                                                placeholder=""
+                                                                name="enum"
+                                                                :refName="'basicField-' + key + '-' + fKey + '-enum'"
+                                                                :idName="'basicField-' + key + '-' + fKey + '-enum'"
+
+                                                                :editing="editing"
+                                                                :value="(field.constraints && field.constraints.enum) ? field.constraints.enum : ''"
+                                                                helpPrefix="schema"
+                                                                :focusField="focusProp"
+                                                                @focus="onFocusBasic"
+                                                                @blur="(event) => { updateResourceEnum(key, fKey, 'constraints', 'enum', event) }"
+                                                            ></TextInput>
+                                                        </v-col>
+
+                                                        <v-col cols=12 v-if="expandedBasic[key][fKey]" class="pt-0 pb-1">
+                                                            <Select
+                                                                :label="$tc('Highlight')"
+                                                                name="highlight"
+                                                                :editing="true"
+                                                                :value="field.highlight"
+                                                                :items="[ {text: 'Yes', value: true}, {text: 'No', value: false}]"
+                                                                helpPrefix="schema"
+                                                                @edited="(newValue) => { updateResourceHighlight(key, fKey, 'highlight', newValue) }"
+                                                            ></Select>
+                                                        </v-col>
+
+                                                        <v-col v-if="expandedBasic[key][fKey]" cols=12 class="pt-0 pb-1">
+                                                        </v-col>
+
+                                                        <v-col v-if="expandedBasic[key][fKey]" cols=12 class="pt-0 pb-1">
+                                                            <v-btn v-if="editing" class="error" @click="removeField(key, fKey)"><v-icon>mdi-minus</v-icon></v-btn>
+                                                        </v-col>
+                                                    </v-row>
                                                 </v-col>
-                                                <v-col cols=9></v-col>
-                                                <v-col cols=12 v-if="(field && field.name) || editing" class="py-1">
-                                                    <TextInput
-                                                        :label="$tc('Name')"
-                                                        placeholder=""
-                                                        name="name"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-name'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-name'"
-                                                        
-                                                        :editing="editing"
-                                                        :value="field.name"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @blur="(event) => { updateResource(key, fKey, 'name', event) }"
-                                                        
-                                                        @focus="onFocusBasic"
-                                                        
-                                                    ></TextInput>
-                                                </v-col>
-                                                <v-col cols=12 v-if="((field && field.title) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Title')"
-                                                        placeholder=""
-                                                        name="title"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-title'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-title'"
-
-                                                        :editing="editing"
-                                                        :value="field.title"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'title', event) }"
-                                                    ></TextInput>
+                                                
+                                                <v-col v-if="expandedBasic[key][fKey]" cols=5 class="borderLeft">
+                                                    <Comments @setComment="(e) => { $emit('setComment', e) }" :id="commentId" :type="'schema'" :resource="resource.name" :field="field.name" :refable="commentRefs"></Comments>
                                                 </v-col>
 
-                                                <v-col cols=12 v-if="((field && field.shortName) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Short Name')"
-                                                        placeholder=""
-                                                        name="shortName"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-shortName'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-shortName'"
-
-                                                        :editing="editing"
-                                                        :value="field.shortName"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'shortName', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.type) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Type')"
-                                                        placeholder=""
-                                                        name="type"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-type'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-type'"
-
-                                                        :editing="editing"
-                                                        :value="field.type"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'type', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.description) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Description')"
-                                                        placeholder=""
-                                                        name="description"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-description'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-description'"
-
-                                                        :editing="editing"
-                                                        :value="field.description"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'description', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.format) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Format')"
-                                                        placeholder=""
-                                                        name="format"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-format'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-format'"
-
-                                                        :editing="editing"
-                                                        :value="field.format"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'format', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.var_class) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <Select
-                                                        :label="$tc('Var Class')"
-                                                        placeholder=""
-                                                        name="var_class"
-                                                        :items="variableClassificationValues"
-                                                        itemText="code"
-                                                        itemValue="code"
-
-                                                        :editing="editing"
-                                                        :value="field.var_class"
-                                                        helpPrefix="schema"
-                                                        @edited="(newValue) => { updateResource(key, fKey, 'var_class', newValue) }"
-                                                    ></Select>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.rdfType) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('RDF Type')"
-                                                        placeholder=""
-                                                        name="rdfType"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-rdfType'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-rdfType'"
-
-                                                        :editing="editing"
-                                                        :value="field.rdfType"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'rdfType', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.tags) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Tags', 2)"
-                                                        placeholder=""
-                                                        name="tags"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-tags'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-tags'"
-
-                                                        :editing="editing"
-                                                        :value="field.tags"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'tags', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.comments) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Comments', 2)"
-                                                        placeholder=""
-                                                        name="comments"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-comments'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-comments'"
-
-                                                        :editing="editing"
-                                                        :value="field.comments"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResource(key, fKey, 'comments', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="((field && field.constraints && field.constraints.enum) || editing) && expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <TextInput
-                                                        :label="$tc('Enum', 1)"
-                                                        placeholder=""
-                                                        name="enum"
-                                                        :refName="'basicField-' + key + '-' + fKey + '-enum'"
-                                                        :idName="'basicField-' + key + '-' + fKey + '-enum'"
-
-                                                        :editing="editing"
-                                                        :value="(field.constraints && field.constraints.enum) ? field.constraints.enum : ''"
-                                                        helpPrefix="schema"
-                                                        :focusField="focusProp"
-                                                        @focus="onFocusBasic"
-                                                        @blur="(event) => { updateResourceEnum(key, fKey, 'constraints', 'enum', event) }"
-                                                    ></TextInput>
-                                                </v-col>
-
-                                                <v-col cols=12 v-if="expandedBasic[key][fKey]" class="pt-0 pb-1">
-                                                    <Select
-                                                        :label="$tc('Highlight')"
-                                                        name="highlight"
-                                                        :editing="true"
-                                                        :value="field.highlight"
-                                                        :items="[ {text: 'Yes', value: true}, {text: 'No', value: false}]"
-                                                        helpPrefix="schema"
-                                                        @edited="(newValue) => { updateResourceHighlight(key, fKey, 'highlight', newValue) }"
-                                                    ></Select>
-                                                </v-col>
-
-                                                <v-col v-if="expandedBasic[key][fKey]" cols=12 class="pt-0 pb-1">
-                                                </v-col>
-
-                                                <v-col v-if="expandedBasic[key][fKey]" cols=12 class="pt-0 pb-1">
-                                                    <v-btn v-if="editing" class="error" @click="removeField(key, fKey)"><v-icon>mdi-minus</v-icon></v-btn>
-                                                </v-col>
+                                                <v-col cols=5 v-if="!expandedBasic[key][fKey]"></v-col>
                                             </v-row>
-                                        </v-col>
+                                        </v-container>
 
-                                        <v-col cols=5 v-if="!expandedBasic[key][fKey]"></v-col>
-                                        
-                                        
-                                        <v-col v-if="expandedBasic[key][fKey]" cols=5 class="py-1 borderLeft rightFillDown">
-                                            <Comments @setComment="(e) => { $emit('setComment', e) }" :id="commentId" :type="'schema'" :resource="resource.name" :field="field.name" :refable="commentRefs"></Comments>
-                                        </v-col>
-                                    </div>
-
-                                </v-row>
-                            </draggable>
+                                    </v-row>
+                                </draggable>
+                            </span>
+                            <v-row>
+                                <v-col cols=2>
+                                    <v-btn v-if="editing" class="primary" @click="addField(key)">{{$tc('Add Field')}}<v-icon>mdi-plus</v-icon></v-btn>
+                                </v-col>
+                                <v-col cols=10>
+                                </v-col>
+                            </v-row>
                         </span>
-                        <v-row>
-                            <v-col cols=2>
-                                <v-btn v-if="editing" class="primary" @click="addField(key)">{{$tc('Add Field')}}<v-icon>mdi-plus</v-icon></v-btn>
-                            </v-col>
-                            <v-col cols=10>
-                            </v-col>
-                        </v-row>
                     </v-col>
                 </span>
                 <v-btn v-if="editing" class="primary" @click="addResource">{{$tc('Add File/Resource')}}</v-btn>
@@ -517,9 +526,11 @@ export default{
 
         variableClassificationValues: function(){
             let rv = [];
-            let k = Object.keys(this.variableClassification.values);
-            for (let i=0; i<k.length; i++){
-                rv.push({code: this.variableClassification.values[k[i]].code + ". " + this.variableClassification.values[k[i]].title})
+            if (this.variableClassification && this.variableClassification.values){
+                let k = Object.keys(this.variableClassification.values);
+                for (let i=0; i<k.length; i++){
+                    rv.push({code: this.variableClassification.values[k[i]].code + ". " + this.variableClassification.values[k[i]].title})
+                }
             }
             return rv;
         },
@@ -579,6 +590,12 @@ export default{
     methods: {
         toggleExpandedBasic: function(key, fKey){
             this.expandedBasic[key][fKey] = !this.expandedBasic[key][fKey];
+            this.reindexKey++;
+            this.$forceUpdate();
+        },
+
+        toggleExpandedBasicResource: function(key){
+            this.expandedBasicResource[key] = !this.expandedBasicResource[key];
             this.reindexKey++;
             this.$forceUpdate();
         },
@@ -643,6 +660,7 @@ export default{
             //}
 
             this.expandedBasic.push([]);
+            this.expandedBasicResource.push(true);
 
             let str = JSON.stringify(this.workingVal, this.replacerFunc(), 4);
             this.workingStr = str;
@@ -856,6 +874,7 @@ export default{
             redrawIndex: 0,
             expandedBasic: [],
             filters: {},
+            expandedBasicResource: [],
         };
     },
 
@@ -865,6 +884,7 @@ export default{
         if (this.workingVal && this.workingVal.resources && this.workingVal){
             for (let i=0; i<this.workingVal.resources.length; i++){
                 this.expandedBasic[i] = [];
+                this.expandedBasicResource[i] = true;
                 if (this.workingVal.resources[i] && this.workingVal.resources[i].schema && this.workingVal.resources[i].schema.fields){
                     for (let j=0; j<this.workingVal.resources[i].schema.fields.length; j++){
                         this.expandedBasic[i][j] = true;
@@ -928,13 +948,6 @@ export default{
     .row.my-0 .col{
         padding-top: 0px;
         padding-bottom: 0px;
-    }
-
-    .rightFillDown{
-        position: absolute;
-        right: 0;
-        top: 0;
-        bottom: 0;
     }
 
     .relativePos{

--- a/frontend/src/components/MetadataForm.vue
+++ b/frontend/src/components/MetadataForm.vue
@@ -15,6 +15,14 @@
             <v-col cols="12">
                 <v-card outlined>
                     <v-card-text>
+                        <v-row v-if="editing">
+                            <v-btn @click="closeOrBack()" class="mt-1">{{$tc('Cancel')}}</v-btn>
+                            <v-btn @click="save" class="mt-1" color="primary">{{$tc('Save')}}</v-btn>
+                        </v-row>
+                        <v-row v-else>
+                            <v-btn @click="closeOrBack()" class="mt-1">{{dialog ? $tc('Close') : $tc('Back')}}</v-btn>
+                            <v-btn v-if="canEdit" @click="editing=!editing; viewSchemaType = 'Provided'" class="mt-1" color="primary">{{$tc('Edit')}}</v-btn>
+                        </v-row>
                         <v-row>
                             <h1 class="display-1 font-weight-thin ml-3 my-3">{{$tc('Metadata')}}</h1>
                         </v-row>

--- a/frontend/src/components/SchemaFilter.vue
+++ b/frontend/src/components/SchemaFilter.vue
@@ -52,10 +52,12 @@ import Select from './Select';
 
             variableClassificationValues: function(){
                 let rv = [];
-                let k = Object.keys(this.variableClassification.values);
-                rv.push({code: ""})
-                for (let i=0; i<k.length; i++){
-                    rv.push({code: this.variableClassification.values[k[i]].code + ". " + this.variableClassification.values[k[i]].title})
+                if (this.variableClassification && this.variableClassification.values){
+                    let k = Object.keys(this.variableClassification.values);
+                    rv.push({code: ""})
+                    for (let i=0; i<k.length; i++){
+                        rv.push({code: this.variableClassification.values[k[i]].code + ". " + this.variableClassification.values[k[i]].title})
+                    }
                 }
                 return rv;
             },

--- a/frontend/src/components/Select.vue
+++ b/frontend/src/components/Select.vue
@@ -134,7 +134,7 @@
             displayVal: function(){
                 let displayVal = this.val;
                 for (let i=0; i<this.items.length; i++){
-                    if (this.items[i].value === this.val){
+                    if (this.items[i][this.itemValue] === this.val){
                         displayVal = this.items[i][this.itemText];
                     }
                 }

--- a/frontend/src/components/pages/upload.vue
+++ b/frontend/src/components/pages/upload.vue
@@ -89,7 +89,9 @@
                                             :label="$tc('Datasets')">
                                         </v-select>
                                     </v-col>
-                                    
+                                    <v-col cols=3>
+                                        <v-btn v-if="allowCreate" color="success" id="newDatasetButton" @click="createDataset">{{$tc('New')}} {{$tc('Datasets')}}</v-btn>
+                                    </v-col>
                                 </v-row>
                                 <v-row>
                                     <v-col cols=9>
@@ -100,6 +102,9 @@
                                             item-value="_id"
                                             :label="$tc('Versions')">
                                         </v-select>
+                                    </v-col>
+                                    <v-col cols=3>
+                                        <v-btn v-if="allowCreateVersion" color="success" :disabled="!selectedDataset || selectedDataset === '-1'" id="newVersionButton" @click="createVersion">{{$tc('New')}} {{$tc('Versions')}}</v-btn>
                                     </v-col>
                                 </v-row>
                             </v-card>
@@ -563,8 +568,10 @@
             },
 
             async createVersion(){
-                return false;
-                // eslint-disable-next-line
+                if (this.user._json.preferred_username !== 'provider_1'){
+                    return false;
+                }
+                
                 if (!this.selectedDataset){
                     this.errorAlert = true;
                     this.errorText = "Must select a " + this.$tc("Datasets") + " first"
@@ -591,8 +598,9 @@
             },
 
             async createDataset(){
-                return false;
-                // eslint-disable-next-line
+                if (this.user._json.preferred_username !== 'provider_1'){
+                    return false;
+                }
                 this.clearDataset();
                 this.editDataset({name: 'name', value: this.upload.name});
                 let d = await this.saveDataset();

--- a/frontend/src/components/pages/upload.vue
+++ b/frontend/src/components/pages/upload.vue
@@ -270,6 +270,12 @@
                     }
                 }
             }
+
+            if (this.user._json.preferred_username === 'provider_1'){
+                this.allowCreate = true;
+                this.allowCreateVersion = true;
+            }
+
             this.loading = false;
         },
         methods: {
@@ -284,6 +290,7 @@
                 updateDataPackageSchema: 'schemaImport/updateDataPackageSchema',
                 getAllRepos: 'repos/getAllRepos',
                 saveDataset: 'repos/saveRepo',
+                getBranchById: 'repos/getBranchById',
                 getBranches: "repos/getBranches",
                 getBranchesByUpload: "repos/getBranchesByUpload",
                 saveBranch: 'repos/saveBranch',
@@ -465,7 +472,7 @@
             },
 
             async stepSaveEditionForm(transitionNextStepAfterSave){
-                if (this.selectedDataset == -1){
+                if (this.selectedDataset == "-1"){
                     this.errorText = "You must select or create a dataset first";
                     this.errorAlert = true;
                     this.transitionNextStepAfterSave = false;
@@ -477,13 +484,22 @@
                     this.errorAlert = true;
                     this.transitionNextStepAfterSave = false;
                     return;
+                }else{
+                    await this.getBranchById({id: this.selectedVersion});
                 }
 
-                this.editBranch({name: 'upload_id', value: this.uploadId});
-                await this.updateBranch();
+                try{
+                    this.editBranch({name: 'upload_id', value: this.uploadId});
+                    await this.updateBranch();
+                }catch(e){
+                    transitionNextStepAfterSave = false;
+                    this.errorAlert = true;
+                    this.errorText = e.message;
+                }
 
 
-
+                this.warningAlert = false;
+                this.warningText = '';
                 if(transitionNextStepAfterSave) { this.step = this.steps.step3FileSelection; }
             },
 
@@ -591,6 +607,7 @@
                 this.editBranch({name: "repo_id", value: this.selectedDataset});
                 let b = await this.saveBranch();
                 this.selectedVersion = b.id;
+                this.editBranch({name: "_id", value: this.selectedVersion});
                 this.allowCreateVersion = false;
                 this.allowSelectVersion = false;
                 await this.getBranches({repoId: this.selectedDataset});
@@ -635,7 +652,7 @@
                 selectedDataset: "-1",
                 jsonRedraw: 0,
                 datasetList: [],
-                allowCreate: true,
+                allowCreate: false,
                 allowSelect: true,
                 selectedVersion: "-1",
                 inferredSchema: {},
@@ -644,7 +661,7 @@
                 providerGroup: null,
                 selectableGroups: [],
                 notFound: false,
-                allowCreateVersion: true,
+                allowCreateVersion: false,
                 allowSelectVersion: true,
                 warningAlert: false,
                 warningText: '',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -43,6 +43,7 @@ export default {
         "Type": "Types | Type | Types",
         "Format": "Formats | Format | Formats",
         "Var Class": "Variable Classification",
+        "var_class": "Variable Classification",
         "RDF Type": "RDF Types | RDF Type | RDF Types",
         "Add File/Resource": "Add File/Resource",
         "Description": "Descriptions | Description | Descriptions",

--- a/frontend/step-definitions/upload.js
+++ b/frontend/step-definitions/upload.js
@@ -51,7 +51,7 @@ Given(/^Data provider successfully uploads a data file$/, async () => {
 
     await client.click('#next-1');
     
-    await client.pause(300);
+    await client.pause(1000);
     await client.click('#newDatasetButton');
     await client.pause(3000);
     await client.click('#newVersionButton');

--- a/frontend/step-definitions/upload.js
+++ b/frontend/step-definitions/upload.js
@@ -51,12 +51,15 @@ Given(/^Data provider successfully uploads a data file$/, async () => {
 
     await client.click('#next-1');
     
-    await client.pause(500);
+    await client.pause(300);
     await client.click('#newDatasetButton');
     await client.pause(3000);
     await client.click('#newVersionButton');
     await client.pause(3000);
+    await client.saveScreenshot("./"+path+"/preNext2.png");
     await client.click('#next-2');
+    await client.pause(300);
+    await client.saveScreenshot("./"+path+"/postNext2.png");
     
     let f = require('path').resolve(__dirname + '/sample.csv');
     await client.setValue('#fileForm-reader input[type="file"]', f);

--- a/frontend/step-definitions/upload.js
+++ b/frontend/step-definitions/upload.js
@@ -54,6 +54,8 @@ Given(/^Data provider successfully uploads a data file$/, async () => {
     await client.pause(500);
     await client.click('#newDatasetButton');
     await client.pause(3000);
+    await client.click('#newVersionButton');
+    await client.pause(3000);
     await client.click('#next-2');
     
     let f = require('path').resolve(__dirname + '/sample.csv');


### PR DESCRIPTION
Fixed issue where delting a data upload would delete the oldest instead of the selected one
Changed selection of upload on edition to allow a searchable table
Added ability to collapse resources on schema view to improve navigation
Added close/back to schema compare page
Hyperlinked Data Upload on Edition page to the data upload it relates to (non edit only)
Made it so that field comments properly expand the field box when there is multiple
Fixed issue where select wasn't showing the proper display value
Removed approved versions from list on upload
Removed ability to create new datasets/editions on the upload page
Fixed issue where variable classifications would prevent basic view of schema
Added next button to top of compare schema on upload
Edition select on upload now saves information into the selected version to bind to the upload
This will warn if the edition has that information already but not prevent it from being overwritten
Added back/close, edit to top of schema page
Added dataset tab to schema page
This closes the dialog if your in a dialog, or shows you the dataset information if you aren't
Added Number of records to file info page for data type files