### PR TITLE
v1.3.2 lots of new fields

### DIFF
--- a/backend/db/model/repoBranch.js
+++ b/backend/db/model/repoBranch.js
@@ -72,7 +72,45 @@ var repoBranchSchema = new Schema({
     faq: {
         type: String,
         required: false,
+    },
+
+    instructions:{
+        type: String,
+        required: false,
+    },
+    inclusions:{
+        type: String,
+        required: false,
+    },
+    exclusions:{
+        type: String,
+        required: false,
+    },
+    quality:{
+        type: String,
+        required: false,
+    },
+    delta_over_time:{
+        type: String,
+        required: false,
+    },
+    additional_info:{
+        type: String,
+        required: false,
+    },
+    references:{
+        type: String,
+        required: false,
+    },
+    keywords:{
+        type: String,
+        required: false,
+    },
+    more_information:{
+        type: String,
+        required: false,
     }
+
 });
 
 

--- a/backend/db/model/revision.js
+++ b/backend/db/model/revision.js
@@ -42,6 +42,14 @@ var revisionSchema = new Schema({
 });
 
 revisionSchema.methods.revise = function(fieldName, previousValue, newValue){
+    if (typeof(previousValue) === 'undefined'){
+        previousValue = ""
+    }
+
+    if (typeof(newValue) === 'undefined'){
+        newValue = ""
+    }
+
     if (typeof(previousValue) === 'object'){
         previousValue = JSON.stringify(previousValue);
     }
@@ -69,6 +77,13 @@ revisionSchema.methods.revise = function(fieldName, previousValue, newValue){
             this.changes = {};
         }
         this.changes[fieldName] = newValue;
+        console.log("Revision, ", fieldName, newValue, previousValue, this);
+    }
+    if (!this.changes){
+        this.changes = {};
+    }
+    if (!this.change_summary){
+        this.change_summary = '';
     }
 }
 

--- a/backend/db/model/variableClassification.js
+++ b/backend/db/model/variableClassification.js
@@ -11,7 +11,7 @@ var possibleValues = new Schema({
 })
 
 var variableClassificationSchema = new Schema({
-    name: {type: String, required: true},
+    name: {type: String, required: true, unique: true},
     values: {type: [possibleValues]},
     create_date: {type: Date, required: true, default: Date.now},
     created_by: {type: String, required: true},

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "Brandon Sharratt",
   "description": "Metadata Curator is a simple web app to edit csvs and to help describe, validate and share usable open data",
   "repository": "https://github.com/bcgov/metadata-curator",

--- a/backend/routes/base/packages.js
+++ b/backend/routes/base/packages.js
@@ -160,7 +160,10 @@ var buildDynamic = function(db, router, auth, ValidationError, cache){
         // do a transformation to make it compatible with the frictionlessdata schema
         newRecord.resources = transformResourcesToFrictionless(newRecord.resources);
 
-        await revision.save();
+        //if change_summary is set there is at least one change
+        if (revision.change_summary){
+            await revision.save();
+        }
 
         return newRecord;
     }

--- a/backend/routes/base/repo.js
+++ b/backend/routes/base/repo.js
@@ -226,8 +226,11 @@ var buildDynamic = function(db, router, auth, forumClient, cache){
             record.ministry_organization = fields.ministry_organization
         }
     
-        let r = await record.save();
-        await revision.save();
+        //if change_summary is set there is at least one change
+        if (revision.change_summary){
+            let r = await record.save();
+            await revision.save();
+        }
         return r;
     }
     

--- a/backend/routes/base/uploads.js
+++ b/backend/routes/base/uploads.js
@@ -8,6 +8,10 @@ var buildDynamic = function(db, router, auth, forumClient, notify, revisionServi
     const config = require('config');
 
     const createDataUpload = async (user, upload) => {
+        console.log("CDU", user.groups);
+        let originalGroups = JSON.parse(JSON.stringify(user.groups));
+        console.log("OG", originalGroups);
+        let originalJWT = user.jwt;
         try {
             const dataUploadSchema = new db.DataUploadSchema;
             const id = mongoose.Types.ObjectId();
@@ -19,9 +23,6 @@ var buildDynamic = function(db, router, auth, forumClient, notify, revisionServi
             if (!user.groups.some( (el) => el === config.get('requiredRoleToCreateRequest'))){
                 throw new Error("Not permitted to create an upload");
             }
-
-            let originalGroups = JSON.parse(JSON.stringify(user.groups));
-            let originalJWT = user.jwt;
 
             if (( (user.isApprover) || (user.isAdmin) ) && !upload.provider_group){
                 throw new Error("Data Approvers must provide a data provider group");
@@ -295,6 +296,7 @@ var buildDynamic = function(db, router, auth, forumClient, notify, revisionServi
             const dataUpload = await createDataUpload(req.user, req.body);
             return res.status(201).json(dataUpload);
         }catch(e){
+            console.log("ERROR post upload", e);
             return res.status(400).json({error: e});
         }
     });

--- a/backend/routes/base/variableClassification.js
+++ b/backend/routes/base/variableClassification.js
@@ -42,6 +42,11 @@ var buildDynamic = function(db, router, auth, forumClient){
             let error = [];
             if (!f.name){
                 error.push("Name is required");
+            }else{
+                let existing = await db.VariableClassification.find({name: f.name});
+                if (existing.length > 0){
+                    error.push("Name must be unique");
+                }
             }
             
             let varClass = new db.VariableClassification;
@@ -116,6 +121,20 @@ var buildDynamic = function(db, router, auth, forumClient){
             }
             
             let varClass = {};
+
+            if (f.name !== varClass.name){
+                let existing = await db.VariableClassification.find({name: f.name});
+                
+                console.log("UPDATING VAR CLASS", mongoose.Types.ObjectId(req.params.varClassId), existing[0]._id, (existing[0]._id != req.params.varClassId) );
+                
+                if (existing.length > 1){
+                    error.push("Name must be unique");
+                }else if ( (existing.length === 1) && (existing[0]._id != req.params.varClassId) ){
+                    error.push("Name must be unique");
+                }
+                console.log("UPDATING, errors", error, error.length);
+            }
+
             if (f.name){
                 varClass.name = f.name;
             }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/frontend/src/changelog.md
+++ b/frontend/src/changelog.md
@@ -2,15 +2,24 @@
 
 <br />
 
-## Version 1.3.1
-February 23, 2022
- - Fixed ability to export
- - Edition page won't allow to proceed if any fields are missing
- - Prevented copy from working when the edition doesn't have a schema
+## Version 1.3.2
+February 25, 2022
+ - Changed Variable Classification export to be _index_name and _index_id
+ - Changed label on Edition to be Variable Classification Index for clarity
+ - Made name a unique field on variable classifications
+ - Fixed error handling when saving variable classifications
+ - Published Edition page shows variable classification index name instead of guid if it can get it, if it can't it is hidden
+ - Added check and uncheck all buttons to export
+ - Fixed header always being grey in export dialog
+ - Added 9 new fields to edition level
+ - Changed bindings on create new upload from this
+ - New Upload from this now sets field on edition level and preemptively saves the upload (this is all required)
+
 
 <br />
 
 ## Table Of Contents
+- [Version 1.3.2 (February 25 2022)](#version-132)
 - [Version 1.3.1 (February 23 2022)](#version-131)
 - [Version 1.3.0 (February 22 2022)](#version-130)
 - [Version 1.2.6 (February 14 2022)](#version-126)
@@ -18,6 +27,14 @@ February 23, 2022
 - [Version 1.2.4 (February 7 2022)](#version-124)
 - [Version 1.2.3 (February 1 2022)](#version-123)
 - [Version 1.2.2 (January 27 2022)](#version-122)
+
+<br />
+
+## Version 1.3.1
+February 23, 2022
+ - Fixed ability to export
+ - Edition page won't allow to proceed if any fields are missing
+ - Prevented copy from working when the edition doesn't have a schema
 
 <br />
 

--- a/frontend/src/components/BranchForm.vue
+++ b/frontend/src/components/BranchForm.vue
@@ -136,6 +136,7 @@
                                                 item-value="_id"
                                                 helpPrefix="edition"
                                                 @edited="(newValue) => { updateValues('upload_id', newValue) }"
+                                                @error="(message) => { (alert = true) && (alertType = 'error') && (alertText = message) }"
                                             ></DataUploadSelect>
                                         </v-col>
                                     </v-row>
@@ -172,8 +173,8 @@
                                         <v-col cols=12>
                                             <Select
                                                 :items="variableClassifications"
-                                                :label="$tc('Variable Classification')"
-                                                :placeholder="$tc('Variable Classification')"
+                                                :label="$tc('Variable Classification Index')"
+                                                :placeholder="$tc('Variable Classification Index')"
                                                 itemText="name"
                                                 itemValue="_id"
                                                 name="variable_classification"
@@ -210,6 +211,132 @@
                                                 :value="(branch) ? branch.citation : ''"
                                                 helpPrefix="edition"
                                                 @edited="(newValue) => { updateValues('citation', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Specific Instructions for appending or linking')"
+                                                :placeholder="$tc('Specific Instructions for appending or linking')"
+                                                name="instructions"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.instructions : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('instructions', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Inclusions')"
+                                                :placeholder="$tc('Inclusions')"
+                                                name="inclusions"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.inclusions : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('inclusions', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Exclusions')"
+                                                :placeholder="$tc('Exclusions')"
+                                                name="exclusions"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.exclusions : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('exclusions', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Quality / Accuracy of Information')"
+                                                :placeholder="$tc('Quality / Accuracy of Information')"
+                                                name="quality"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.quality : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('quality', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Data changes over time')"
+                                                :placeholder="$tc('Data changes over time')"
+                                                name="delta_over_time"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.delta_over_time : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('delta_over_time', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextArea
+                                                :label="$tc('Important Additional Information')"
+                                                :placeholder="$tc('Important Additional Information')"
+                                                name="additional_info"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.additional_info : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('additional_info', newValue) }"
+                                            ></TextArea>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('References / Research that uses data')"
+                                                :placeholder="$tc('References / Research that uses data')"
+                                                name="references"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.references : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('references', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Keywords')"
+                                                :placeholder="$tc('Keywords')"
+                                                name="keywords"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.keywords : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('keywords', newValue) }"
+                                            ></TextInput>
+                                        </v-col>
+                                    </v-row>
+
+                                    <v-row>
+                                        <v-col cols=12>
+                                            <TextInput
+                                                :label="$tc('Hyperlink to more information')"
+                                                :placeholder="$tc('Hyperlink to more information')"
+                                                name="more_information"
+                                                :editing="editing"
+                                                :value="(branch) ? branch.more_information : ''"
+                                                helpPrefix="edition"
+                                                @edited="(newValue) => { updateValues('more_information', newValue) }"
                                             ></TextInput>
                                         </v-col>
                                     </v-row>
@@ -314,7 +441,7 @@
                     </template>
 
                     <v-card>
-                        <v-card-title class="text-h5 grey lighten-2">
+                        <v-card-title class="text-h5">
                             Export Fields
                         </v-card-title>
 
@@ -331,15 +458,28 @@
                                         </Select>
                                     </v-col>
                                 </v-row>
+
+                                <v-row>
+                                    <v-col cols=4>
+                                        <v-btn @click="exportCheckAll">Check All</v-btn>
+                                    </v-col>
+                                    <v-col cols=4>
+                                        <v-btn @click="exportUncheckAll">Uncheck All</v-btn>
+                                    </v-col>
+                                    <v-col cols=4>
+                                    </v-col>
+                                </v-row>
+                                
                                 <v-row>
                                     <v-col cols=6 v-for="(checked, key) in exportFields" :key="'export-field-'+key">
                                         <SimpleCheckbox
-                                            :label="$tc(key)"
-                                            :placeholder="$tc(key)"
+                                            :label="key"
+                                            :placeholder="key"
                                             :name="key"
                                             :editing="true"
                                             :checked="checked"
                                             helpPrefix="export"
+                                            :disabled="key!=='all' && exportFields['all'] === true"
                                             @edited="(newValue) => { exportFields[key] = newValue }"
                                         ></SimpleCheckbox>
                                     </v-col>
@@ -461,6 +601,21 @@ export default {
             clearBranch: 'repos/clearBranch',
         }),
 
+        exportFieldsSetAll(value){
+            let keys = Object.keys(this.exportFields);
+            for (let i=0; i<keys.length; i++){
+                this.exportFields[keys[i]] = value;
+            }
+        },
+
+        exportCheckAll(){
+            this.exportFieldsSetAll(true);
+        },
+
+        exportUncheckAll(){
+            this.exportFieldsSetAll(false);
+        },
+
         changeTab(){
             if (this.tab === 1 && this.dialog){
                 this.$nextTick(() => {
@@ -482,6 +637,9 @@ export default {
                     for (let j=0; j<datasetKeys.length; j++){
                         this.exportFields[this.DATASET_PREFIX+'.'+datasetKeys[j]] = true;
                     }
+                }else if (keys[i] === 'variable_classification'){
+                    keys[i] = "variable_classification_index";
+                    this.exportFields[keys[i]] = true;
                 }else{
                     this.exportFields[keys[i]] = true;
                 }
@@ -516,7 +674,12 @@ export default {
                 if (k !== 'all'){
                     if (k.indexOf('.') === -1){
                         if (this.exportFields['all'] || this.exportFields[k]){
-                            json[k] = this.branch[k];
+                            if (this.exportFields[k] === "variable_classification_index"){
+                                json[k+"_id"] = this.branch[k];
+                                json[k+"_name"] = this.variableClassification.name;
+                            }else{
+                                json[k] = this.branch[k];
+                            }
                         }
                     }else if(k.indexOf(this.DATASET_PREFIX) === 0){
                         if (this.exportFields['all'] || this.exportFields[k]){
@@ -525,35 +688,32 @@ export default {
                         }
                     }else if ( (k.indexOf(this.FIELD_PREFIX) === 0) || (k.indexOf(this.RESOURCE_PREFIX) === 0) ){
                         //only need to do this if not doing all as it's caught above for all
-                        if (!this.exportFields['all'] || this.exportFields[k]){
+                        if (!this.exportFields['all'] && this.exportFields[k]){
                             let isField = (k.indexOf(this.FIELD_PREFIX) === 0) ;
                             let fieldK=k.substring(this.FIELD_PREFIX.length+1);
                             let resourceK=k.substring(this.RESOURCE_PREFIX.length+1);
                             for (let j=0; j<this.schema.resources.length; j++){
-                                if (!json.schema){
-                                    json.schema = {}
+                                if (!json.resources){
+                                    json.resources = [];
                                 }
-                                if (!json.schema.resources){
-                                    json.schema.resources = [];
+                                if (!json.resources[j]){
+                                    json.resources[j] = {};
                                 }
-                                if (!json.schema.resources[j]){
-                                    json.schema.resources[j] = {};
-                                }
-                                if (!json.schema.resources[j].schema){
-                                    json.schema.resources[j].schema = {}
+                                if (!json.resources[j].schema){
+                                    json.resources[j].schema = {}
                                 }
                                 if (!isField){
-                                    json.schema.resources[j].schema[resourceK] = this.schema.resources[j].schema[resourceK];
+                                    json.resources[j].schema[resourceK] = this.schema.resources[j].schema[resourceK];
                                 }else{
-                                    if (!json.schema.resources[j].schema.fields){
-                                        json.schema.resources[j].schema.fields = []
+                                    if (!json.resources[j].schema.fields){
+                                        json.resources[j].schema.fields = []
                                     }
 
                                     for (let k=0; k<this.schema.resources[j].schema.fields.length; k++){
-                                        if (!json.schema.resources[j].schema.fields[k]){
-                                            json.schema.resources[j].schema.fields[k] = {};
+                                        if (!json.resources[j].schema.fields[k]){
+                                            json.resources[j].schema.fields[k] = {};
                                         }
-                                        json.schema.resources[j].schema.fields[k][fieldK] = this.schema.resources[j].schema.fields[k][fieldK];
+                                        json.resources[j].schema.fields[k][fieldK] = this.schema.resources[j].schema.fields[k][fieldK];
                                     }
                                 }
                             }
@@ -714,6 +874,7 @@ export default {
             schema: state => state.schemaImport.tableSchema,
             inferredSchema: state => state.schemaImport.inferredSchema,
             variableClassifications: state => state.variableClassifications.items,
+            variableClassification: state => state.variableClassifications.wipItem,
             revisions: state => state.repos.branchRevisions,
             revisionsLoading: state => state.repos.branchRevisionsLoading,
             schemaRevisions: state => state.schemaImport.revisions,

--- a/frontend/src/components/DateInput.vue
+++ b/frontend/src/components/DateInput.vue
@@ -33,7 +33,7 @@
         </span>
 
         <span v-else>
-            <ValidationProvider ref="provider" :rules="validationRules" v-slot="{ errors }" :name="label ? $tc(label) : $tc(name)">
+            <ValidationProvider ref="provider" :rules="validationRules" v-slot="{ errors }" :name="label ? ($te(label) ? $tc(label) : label) : ($te(name) ? $tc(name) : name)">
                 <v-menu
                     v-model="menuOpen"
                     :close-on-content-click="false"
@@ -44,7 +44,7 @@
                 >
                     <template v-slot:activator="{ on, attrs }">
                         <v-text-field
-                            :placeholder="$tc(placeholder)"
+                            :placeholder="placeholder"
                             v-model="val"
                             :label="displayLabel"
                             prepend-icon="mdi-calendar"
@@ -182,9 +182,9 @@
         computed: {
             displayLabel: function(){
                 if (this.validationRules.toLowerCase().indexOf("required") >= 0) {
-                    return this.$tc(this.label) + ' *';
+                    return this.$te(this.label) ? (this.$tc(this.label) + ' *') : this.label + ' *';
                 }
-                return this.$tc(this.label);
+                return this.$te(this.label) ? this.$tc(this.label) : this.label;
             }
         },
         watch: {

--- a/frontend/src/components/Select.vue
+++ b/frontend/src/components/Select.vue
@@ -32,7 +32,7 @@
         </span>
 
         <span v-else>
-            <ValidationProvider :rules="validationRules" v-slot="{ errors }" :name="label ? $tc(label) : $tc(name)">
+            <ValidationProvider :rules="validationRules" v-slot="{ errors }" :name="label ? ($te(label) ? $tc(label) : label) : ($te(name) ? $tc(name) : name)">
                 <v-select
                     :name="name"
                     v-model="val"

--- a/frontend/src/components/SimpleCheckbox.vue
+++ b/frontend/src/components/SimpleCheckbox.vue
@@ -9,7 +9,7 @@
         >
         </v-checkbox>
         <span class="higher">
-            {{$tc(label)}}
+            {{displayLabel}}
             <v-tooltip right v-model="showTooltip" v-if="$te('help.'+((helpPrefix) ? helpPrefix + '.' + name : name))">
                 <template v-slot:activator="{}">
                     <v-icon color="label_colour" 
@@ -77,6 +77,9 @@
                 }
                 return marked(t);
             },
+            displayLabel: function(){
+                return this.$te(this.label) ? this.$tc(this.label) : this.label;
+            }
         },
         mounted() {
             // console.log(`mounted - checked: ${this.checked}, color: ${this.color}`);

--- a/frontend/src/components/VariableClassificationForm.vue
+++ b/frontend/src/components/VariableClassificationForm.vue
@@ -226,6 +226,13 @@ export default {
         save(){
             if (this.creating){
                 this.saveVariableClassification({item: this.variableClassification}).then( async() => {
+                        if (this.variableClassificationError !== ""){
+                            this.alertType = "error"
+                            this.alertText = this.variableClassificationError;
+                            this.alert = true;
+                            window.scrollTo(0,0);
+                            return;
+                        }
                         this.alertType = "success"
                         this.alertText = this.$tc("Sucessfully created variable classification");
                         this.alert = true;
@@ -241,6 +248,13 @@ export default {
                     });
             }else{
                 this.updateVariableClassification({id: this.id, item: this.variableClassification}).then( async() => {
+                        if (this.variableClassificationError !== ""){
+                            this.alertType = "error"
+                            this.alertText = this.variableClassificationError;
+                            this.alert = true;
+                            window.scrollTo(0,0);
+                            return;
+                        }
                         this.alertType = "success"
                         this.alertText = this.$tc("Sucessfully updated variable classification");
                         this.alert = true;
@@ -262,6 +276,7 @@ export default {
         ...mapState({
             user: state => state.user.user,
             variableClassification: state => state.variableClassifications.wipItem,
+            variableClassificationError: state => state.variableClassifications.error,
         }),
     },
     created() {

--- a/frontend/src/components/pages/publishedVersion.vue
+++ b/frontend/src/components/pages/publishedVersion.vue
@@ -58,8 +58,8 @@
                                 </v-row>
 
                                 <v-row>
-                                    <v-col cols=12 v-if="branch && branch.variable_classification">
-                                        Variable Classification: {{branch.variable_classification}}
+                                    <v-col cols=12 v-if="variableClassification && variableClassification.name">
+                                        {{$tc('Variable Classification Index')}}: {{variableClassification.name}}
                                     </v-col>
                                 </v-row>
 
@@ -133,11 +133,15 @@ export default {
             getBranchById: 'repos/getBranchById',
             getRepos: 'repos/getAllRepos',
             getSchema: 'schemaImport/getTableSchema',
+            getVariableClassification: 'variableClassifications/getItem',
         }),
 
         async loadSections() {
             await this.getBranchById({id: this.id});
             await this.getSchema({id: this.id});
+            if (this.branch.variable_classification){
+                await this.getVariableClassification({field: '_id', value: this.branch.variable_classification});
+            }
             this.reIndex++;
         },
 
@@ -155,6 +159,7 @@ export default {
             dataUploads: state => state.dataUploads.dataUploads,
             dataset: state => state.repos.repo,
             schema: state => state.schemaImport.tableSchema,
+            variableClassification: state => state.variableClassifications.wipItem,
         }),
     },
     

--- a/frontend/src/components/pages/upload.vue
+++ b/frontend/src/components/pages/upload.vue
@@ -415,7 +415,7 @@
                       
                     const initialUpload = {
                         name: submission.data.datasetName,
-                        description: submission.datauploadDescription,
+                        description: submission.data.uploadDescription,
                         uploader: this.user.email,
                         upload_submission_id: data._id,
                         form_name: this.formName,
@@ -467,7 +467,7 @@
                     if (this.user.isApprover || this.user.isAdmin){
                         this.step = (this.enabledPhase >= 2) ? this.steps.step2EditionForm : this.steps.step3FileSelection;
                     }else{
-                        if ( (this.enabledPhase >= 2) && (this.selectedVersion === "-1") && (this.user._json.preferred_username !== TEST_ACCOUNT) ){
+                        if ( (this.enabledPhase >= 2) && (this.selectedVersion == "-1") && (this.user._json.preferred_username !== TEST_ACCOUNT) ){
                             this.errorAlert = true;
                             this.errorText = "You are not allowed to proceed until this upload has been assigned an "+this.$tc('version',1);
                             return false;
@@ -784,7 +784,7 @@
             },
 
             selectedVersion: async function(){
-                if (this.selectedVersion != -1){
+                if (this.selectedVersion != "-1"){
                     await this.getSchemaFromVersion({id: this.selectedVersion});
                     let selectedV = this.versions.filter(obj => {
                         return obj._id === this.selectedVersion;

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -234,6 +234,19 @@ export default {
         "Revisions": "Revisions",
         "Revised By": "Revised By",
         "Schema Revisions": "Schema Revisions",
+        "Variable Classification Index": "Variable Classification Index",
+        "Field values": "Field values",
+
+        "Specific Instructions for appending or linking": "Specific Instructions for appending or linking",
+        "Inclusions": "Inclusions",
+        "Exclusions": "Exclusions",
+        "Quality / Accuracy of Information": "Quality / Accuracy of Information",
+        "Data changes over time": "Data changes over time",
+        "Important Additional Information": "Important Additional Information",
+        "References / Research that uses data": "References / Research that uses data",
+        "Keywords": "Keywords",
+        "Hyperlink to more information": "Hyperlink to more information",
+        "Ministry / Organization": "Ministry / Organization",
 
 
         "help.dataset.name": "The name of the dataset",

--- a/frontend/src/store/modules/items.js
+++ b/frontend/src/store/modules/items.js
@@ -52,22 +52,30 @@ var build = function(getFn, newFn, updateFn, deleteFn, getSingle){
             }
         },
 
-        newItem({commit}, {item}){
-            backend[newFn](item).then((data) => {
+        async newItem({commit}, {item}){
+            try{
+                let data = backend[newFn](item);
                 let newItems = state.items.slice();
                 if (data.item){
                     newItems.push(data.item);
                 }else{
                     newItems.push(item);
                 }
+                commit('setError', {error: ""});
                 commit('setItems', {items: newItems});
-            }).catch((e) => {
-                commit('setError', {error: "Error Creating: " + e.message});
-            });
+            }catch(e){
+                if (e && e.response && e.response.data){
+                    commit('setError', {error: "Error creating: " + e.response.data});
+                }else{
+                    commit('setError', {error: "Error creating: " + e.message});
+                }
+            }
         },
 
-        updateItem({commit}, {id, item}){
-            backend[updateFn](id, item).then(() => {
+        async updateItem({commit}, {id, item}){
+            try{
+                await backend[updateFn](id, item);
+                
                 let newItems = state.items.slice();
                 for (var i=0; i<newItems.length; i++){
                     if (newItems[i]._id === id){
@@ -75,10 +83,15 @@ var build = function(getFn, newFn, updateFn, deleteFn, getSingle){
                         break;
                     }
                 }
+                commit('setError', {error: ""});
                 commit('setItems', {items: newItems});
-            }).catch((e) => {
-                commit('setError', {error: "Error updating: " + e.message});
-            });
+            }catch(e){
+                if (e && e.response && e.response.data){
+                    commit('setError', {error: "Error updating: " + e.response.data});
+                }else{
+                    commit('setError', {error: "Error updating: " + e.message});
+                }
+            }
         },
     }
 
@@ -138,7 +151,9 @@ var build = function(getFn, newFn, updateFn, deleteFn, getSingle){
                         newItems.push(state.items[i]);
                     }
                 }
+                commit('setError', {error: ""});
                 commit('setItems', {items: newItems});
+                
             }).catch((e) => {
                 commit('setError', {error: "Error updating: " + e.message});
             });

--- a/frontend/src/store/modules/schemaImport.js
+++ b/frontend/src/store/modules/schemaImport.js
@@ -72,7 +72,9 @@ const actions = {
         commit('setDataPackageSchema', {schema: null});
         let s = await backend.getTableSchema(id);
         commit('setDataPackageSchema', {schema: s});
-        dispatch('getRevisions', {id: s._id});
+        if (s && s._id){
+            dispatch('getRevisions', {id: s._id});
+        }
         return s;
     },
 
@@ -81,7 +83,9 @@ const actions = {
         let s = await backend.getTableSchema(id, true);
         if (s && s.length > 0){
             commit('setDataPackageSchema', {schema: s[0]});
-            dispatch('getRevisions', {id: s[0]._id});
+            if (s && s[0] && s[0]._id){
+                dispatch('getRevisions', {id: s[0]._id});
+            }
         }
         return s;
     },


### PR DESCRIPTION
 - Changed Variable Classification export to be _index_name and _index_id
 - Changed label on Edition to be Variable Classification Index for clarity
 - Made name a unique field on variable classifications
 - Fixed error handling when saving variable classifications
 - Published Edition page shows variable classification index name instead of guid if it can get it, if it can't it is hidden
 - Added check and uncheck all buttons to export
 - Fixed header always being grey in export dialog
 - Added 9 new fields to edition level
 - Changed bindings on create new upload from this
 - New Upload from this now sets field on edition level and preemptively saves the upload (this is all required)