### PR TITLE
v145

### DIFF
--- a/backend/auth/auth.js
+++ b/backend/auth/auth.js
@@ -35,6 +35,7 @@ passport.use('jwt', new JWTStrategy({
               try{
                 var u = await db.User.findOne({email: decodedJWT.email});
                 decodedJWT.lastLogin = u.lastLogin;
+                decodedJWT.bcdcSet = u.bcdc_apiKey && u.bcdc_accessKey;
                 decodedJWT = await buildActivity(decodedJWT);
               }catch(ex){
                 console.log("No previous user info", ex);

--- a/backend/db/model/repoBranch.js
+++ b/backend/db/model/repoBranch.js
@@ -113,6 +113,11 @@ var repoBranchSchema = new Schema({
     bcdc_record: {
         type: String,
         required: false,
+    },
+    bcdc_record_is_sunset: {
+        type: Boolean,
+        required: false,
+        default: false,
     }
 
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata_curator",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": "Brandon Sharratt",
   "description": "Metadata Curator is a simple web app to edit csvs and to help describe, validate and share usable open data",
   "repository": "https://github.com/bcgov/metadata-curator",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-curator",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/frontend/src/changelog.md
+++ b/frontend/src/changelog.md
@@ -2,27 +2,20 @@
 
 <br />
 
-## Version 1.4.4
-April 25, 2022
- - Fixed edit button not showing on approved editions for approvers
- - Fixed left message when a user is on nothing and closes browser getting sent to people also on nothing
- - Removed requirement for a upload to publish to the catalogue
- - Added name to dataset list filter
- - Allowed multiple select of ministry on dataset list
- - Switched to semantic infer from data package infer to infer more information about fields
- - After switching to default collapsed for resources/fields on files and fields tab of editions comments no longer hyperlinked
-   - The link doesn't make sense when closed as is as the field isn't visible therefore...
-   - Greatly changed how this works and will now treat ALL instances of !stuff.moreStuff as a link
-   - These links only work on the edition page
-   - If you are on the edition page you will get moved to the files and fields tab (so you can direct link to a field)
-   - If you are on the files and fields tab the resource and field will be opened up and then you will be scrolled to it
-- Added number of fields to comparison
+## Version 1.4.5
+April 27, 2022
+ - Removed blank option from dataset list ministry organization filter
+ - Fields and resources with spaces in the name replace with a + for the comment link to make them work
+ - Duplicate fields (same field name in a resource) in files & fields will be flagged with a red border and an alert will be displayed at the top
+ - Made field notes a text area (files and fields tab)
+ - Publish to BCDC now adds "- [Edition name]" to the dataset
 
 
 
 <br />
 
 ## Table Of Contents
+- [Version 1.4.5 (April 27 2022)](#version-145)
 - [Version 1.4.4 (April 25 2022)](#version-144)
 - [Version 1.4.3 (April 22 2022)](#version-143)
 - [Version 1.4.2 (March 25 2022)](#version-142)
@@ -41,6 +34,24 @@ April 25, 2022
 - [Version 1.2.4 (February 7 2022)](#version-124)
 - [Version 1.2.3 (February 1 2022)](#version-123)
 - [Version 1.2.2 (January 27 2022)](#version-122)
+
+<br />
+
+## Version 1.4.4
+April 25, 2022
+ - Fixed edit button not showing on approved editions for approvers
+ - Fixed left message when a user is on nothing and closes browser getting sent to people also on nothing
+ - Removed requirement for a upload to publish to the catalogue
+ - Added name to dataset list filter
+ - Allowed multiple select of ministry on dataset list
+ - Switched to semantic infer from data package infer to infer more information about fields
+ - After switching to default collapsed for resources/fields on files and fields tab of editions comments no longer hyperlinked
+   - The link doesn't make sense when closed as is as the field isn't visible therefore...
+   - Greatly changed how this works and will now treat ALL instances of !stuff.moreStuff as a link
+   - These links only work on the edition page
+   - If you are on the edition page you will get moved to the files and fields tab (so you can direct link to a field)
+   - If you are on the files and fields tab the resource and field will be opened up and then you will be scrolled to it
+- Added number of fields to comparison
 
 <br />
 

--- a/frontend/src/components/BranchForm.vue
+++ b/frontend/src/components/BranchForm.vue
@@ -355,13 +355,13 @@
                                     <v-row v-if="enabledPhase >= 3 && branch && branch.bcdc_record">
                                         <v-col cols=12>
                                             Catalogue: <a :href="branch.bcdc_record">{{branch.bcdc_record}}</a>
-                                            <v-btn :disabled="disableSunset" v-if="user && (user.isAdmin || user.isApprover) && user.bcdcSet" color="error" @click="goSunsetBCDC">
+                                            <!-- <v-btn :disabled="disableSunset" v-if="user && (user.isAdmin || user.isApprover) && user.bcdcSet" color="error" @click="goSunsetBCDC">
                                                 {{$tc('Sunset Record')}}
                                                 <v-progress-circular
                                                     indeterminate
                                                     v-if="disableSunset"
                                                 ></v-progress-circular>
-                                            </v-btn>
+                                            </v-btn> -->
                                         </v-col>
                                     </v-row>
                                 </ValidationObserver>

--- a/frontend/src/components/BranchForm.vue
+++ b/frontend/src/components/BranchForm.vue
@@ -355,6 +355,13 @@
                                     <v-row v-if="enabledPhase >= 3 && branch && branch.bcdc_record">
                                         <v-col cols=12>
                                             Catalogue: <a :href="branch.bcdc_record">{{branch.bcdc_record}}</a>
+                                            <v-btn :disabled="disableSunset" v-if="user && (user.isAdmin || user.isApprover) && user.bcdcSet" color="error" @click="goSunsetBCDC">
+                                                {{$tc('Sunset Record')}}
+                                                <v-progress-circular
+                                                    indeterminate
+                                                    v-if="disableSunset"
+                                                ></v-progress-circular>
+                                            </v-btn>
                                         </v-col>
                                     </v-row>
                                 </ValidationObserver>
@@ -598,6 +605,7 @@ export default {
             filters: {},
             accessKey: '',
             disablePublish: false,
+            disableSunset: false,
         }
     },
     methods: {
@@ -649,6 +657,27 @@ export default {
             }
             this.alert = true;
             this.disablePublish = false;
+            window.scrollTo(0,0);
+        },
+
+        async goSunsetBCDC(){
+            this.disablePublish = true;
+            this.disableSunset = true;
+            const backend = new Backend();
+            try{
+                let catR = await backend.sunsetBCDC(this.id, this.accessKey);
+                console.log(catR);
+                this.alertType = "success";
+                let alertText = "Record: " + catR.url;
+                this.alertText = alertText;
+            }catch(ex){
+                this.alertType = "error";
+                this.alertText = "Error: " + ( (ex.response && ex.response.data && ex.response.data.error) ? ex.response.data.error : ex.message) +"\n";
+                this.alertText += (ex.response && ex.response.data && ex.response.data.ex) ? ex.response.data.ex : '';
+            }
+            this.alert = true;
+            this.disablePublish = false;
+            this.disableSunset = false;
             window.scrollTo(0,0);
         },
 
@@ -942,7 +971,7 @@ export default {
             }else{
                 this.updateBranch().then( () => {
                     this.alertType = "success"
-                    this.alertText = "Sucessfully updated version";
+                    this.alertText = "Successfully updated edition";
                     this.alert = true;
                     //this.closeOrBack();
                     this.editing = false;

--- a/frontend/src/components/Comments.vue
+++ b/frontend/src/components/Comments.vue
@@ -8,7 +8,7 @@
 
         <v-row v-if="commentDisplayItems.length == 0 && type === 'schema'" class="ml-3">
             <v-col cols=12>
-                {{$tc('No comments about this field, reference with ')}}!{{resource}}.{{field}}
+                {{$tc('No comments about this field, reference with ')}}!{{resource.replaceAll(' ', '+')}}.{{field.replaceAll(' ','+')}}
             </v-col>
         </v-row>
         <v-row v-else>
@@ -172,7 +172,7 @@ const backend = new Backend();
                     let fieldRef = "!" + self.resource + "." + self.field;
 
                     if ( (self.type !== 'schema') || ( (fieldRef.length > 2) && (comment.comment.indexOf(fieldRef) !== -1) ) ){
-                        item.content = item.content.replace(anchorRegex, "[$1](#$1)");
+                        item.content = item.content.replace(anchorRegex, "[!$1](#$1)");
                         
                         if (self.commentDisplayItems.length > 0){
                             self.commentDisplayItems.push({ divider: true, inset: true });
@@ -221,7 +221,7 @@ const backend = new Backend();
             },
 
             scrollBottom(){
-                let fieldRef = "!" + this.resource + "." + this.field;
+                let fieldRef = "!" + this.resource.replaceAll(' ', '+') + "." + this.field.replaceAll(' ', '+');
                 window.scrollTo(0,document.body.scrollHeight);
                 this.$emit("setComment", fieldRef);
             }

--- a/frontend/src/components/Datasets.vue
+++ b/frontend/src/components/Datasets.vue
@@ -125,7 +125,7 @@ export default {
         }),
 
         filterOrgItems: function(){
-            let rv = [{value: false, text: ""}];
+            let rv = [];
             let rvValues = [];
             this.repos.forEach( (repo) => {
                 if (rvValues.indexOf(repo.ministry_organization) === -1){

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -289,6 +289,8 @@ export default {
         "temporal_end": "Temporal End",
         "temporal_start": "Temporal Start",
 
+        "Resource Notes": "Resource Notes",
+
         "help.dataset.name": "The name of the dataset",
         "help.dataset.description": "A description of the dataset",
         "help.dataset.gov_allow_publish": "Is this allowed to be published to government DAR",

--- a/frontend/src/services/backend.js
+++ b/frontend/src/services/backend.js
@@ -426,4 +426,9 @@ export class Backend {
         return axios.post(url, {accessKey: accessKey}, {withCredentials: true}).then(response => response.data)
     }
 
+    sunsetBCDC(branchId, accessKey){
+        const url = `/api/v1/repobranches/${branchId}/bcdc_sunset`;
+        return axios.post(url, {accessKey: accessKey}, {withCredentials: true}).then(response => response.data)
+    }
+
 }

--- a/frontend/tests/step-definitions/schema.js
+++ b/frontend/tests/step-definitions/schema.js
@@ -76,7 +76,7 @@ var workingSchema = {
         selector2: '#basicField-0-0-tags',
     },
     notes: {
-        selector: 'input[name="notes"]',
+        selector: 'textarea[name="notes"]',
         value: "field 0 notes",
         selector2: '#basicField-0-0-notes',
     },


### PR DESCRIPTION
 - Removed blank option from dataset list ministry organization filter
 - Fields and resources with spaces in the name replace with a + for the comment link to make them work
 - Duplicate fields (same field name in a resource) in files & fields will be flagged with a red border and an alert will be displayed at the top
 - Made field notes a text area (files and fields tab)
 - Publish to BCDC now adds "- [Edition name]" to the dataset